### PR TITLE
Fix error: "Cannot convert non-finite values (NA or inf) to integer"

### DIFF
--- a/configs/frameworks_example.ini
+++ b/configs/frameworks_example.ini
@@ -36,8 +36,24 @@ max_retries = 10
 # Template ID will need to be retrieved for each document. Please follow the reference guide above for instructions on how to get your template ID.
 template_id = 126024
 
-[openvas]
+[qualys_vuln]
+#Reference https://www.qualys.com/docs/qualys-was-api-user-guide.pdf to find your API
 enabled = true
+hostname = qualysapi.qg2.apps.qualys.com
+username = exampleuser
+password = examplepass
+write_path=/opt/vulnwhisperer/qualys/
+db_path=/opt/vulnwhisperer/database
+verbose=true
+
+# Set the maximum number of retries each connection should attempt.
+#Note, this applies only to failed connections and timeouts, never to requests where the server returns a response.
+max_retries = 10
+# Template ID will need to be retrieved for each document. Please follow the reference guide above for instructions on how to get your template ID.
+template_id = 126024
+
+[openvas]
+enabled = false
 hostname = localhost
 port = 4000
 username = exampleuser

--- a/vulnwhisp/frameworks/qualys_vuln.py
+++ b/vulnwhisp/frameworks/qualys_vuln.py
@@ -60,7 +60,9 @@ class qualysWhisperAPI(object):
         scan_json = self.qgc.request(self.SCANS, parameters)
         
         # First two columns are metadata we already have
-        return pd.read_json(scan_json).iloc[2:]
+        # Last column corresponds to "target_distribution_across_scanner_appliances" element
+	# which doesn't follow the schema and breaks the pandas data manipulation
+	return pd.read_json(scan_json).iloc[2:-1]
 
 class qualysUtils:
     def __init__(self):


### PR DESCRIPTION
When trying to download the results of Qualys Vulnerability Management scans, the following error pops up:

[FAIL] - Could not process scan/xxxxxxxxxx.xxxxx - Cannot convert non-finite values (NA or inf) to integer

This error is due to pandas operating with the scan results json file, as the last element from the json doesn't fir with the rest of the response's scheme: that element is "target_distribution_across_scanner_appliances", which contains the scanners used and the IP ranges that each scanner went through.

Taking out the last line solves the issue.

Also adding the qualys_vuln scheme to the frameworks_example.ini